### PR TITLE
Add bitHound dependencies badges to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# canduit [![Build status](https://travis-ci.org/uber/canduit.png?branch=master)](https://travis-ci.org/uber/canduit) [![bitHound Score](https://www.bithound.io/github/uber/canduit/badges/score.svg)](https://www.bithound.io/github/uber/canduit)
+# canduit 
+[![Build status](https://travis-ci.org/uber/canduit.png?branch=master)](https://travis-ci.org/uber/canduit) [![bitHound Score](https://www.bithound.io/github/uber/canduit/badges/score.svg)](https://www.bithound.io/github/uber/canduit) [![bitHound Dependencies](https://www.bithound.io/github/uber/canduit/badges/dependencies.svg)](https://www.bithound.io/github/uber/canduit/master/dependencies/npm) [![bitHound Dev Dependencies](https://www.bithound.io/github/uber/canduit/badges/devDependencies.svg)](https://www.bithound.io/github/uber/canduit/master/dependencies/npm)
 
 Node.js Phabricator Conduit API client.
 


### PR DESCRIPTION
Great to see the bitHound score badge on the project! We have dependencies badges now too, so here's a PR to add those as well.