### PR TITLE
Allow setting token via createCanduit options

### DIFF
--- a/canduit.js
+++ b/canduit.js
@@ -22,6 +22,7 @@ function Canduit (opts, cb) {
   this.api = opts.api;
   this.user = opts.user;
   this.cert = opts.cert;
+  this.token = opts.token;
 
   this.configFile = opts.configFile ||
     path.join(process.env.HOME, '.arcrc');


### PR DESCRIPTION
Looks like createCanduit hasn't been updated yet to take in token as a config option