### PR TITLE
load default config only if config parameters are not passed

### DIFF
--- a/canduit.js
+++ b/canduit.js
@@ -45,20 +45,20 @@ function Canduit (opts, cb) {
   this.token = opts.token;
 
   this.configFile = opts.configFile;
-  if (!this.configFile) {
-    if (process.env.HOME) {
-      this.configFile = path.join(process.env.HOME, '.arcrc');
-    } else {
-      var noHomeEnvError = new Error(
-        'Unable to find $HOME/.arcrc: ' +
-        '$HOME env variable is not defined.'
-      );
-      return cb(noHomeEnvError, null);
-    }
-  }
 
   var self = this;
   if (!this.api) {
+    if (!this.configFile) {
+      if (process.env.HOME) {
+        this.configFile = path.join(process.env.HOME, '.arcrc');
+      } else {
+        var noHomeEnvError = new Error(
+          'Unable to find $HOME/.arcrc: ' +
+          '$HOME env variable is not defined.'
+        );
+        return cb(noHomeEnvError, null);
+      }
+    }
     this.parseConfigFile(function (err) {
       if (err) return cb(err, null);
       self.authenticate(cb);

--- a/test/index.js
+++ b/test/index.js
@@ -136,6 +136,19 @@ test('authenticating with passed config parameters', function (t) {
   }, shouldSucceed(t));
 });
 
+test('authenticating with passed config parameters and missing HOME env', function (t) {
+  var HOME = process.env.HOME;
+  delete process.env.HOME;
+  createCanduit({
+    user: 'user',
+    cert: 'cert',
+    api: 'http://localhost:' + fixtures.port + '/api/'
+  }, function (err, result) {
+    process.env.HOME = HOME;
+    shouldSucceed(t)(err, result);
+  });
+});
+
 test('requesting conduit api', function (t) {
   fixtures.addFixture('/api/user.query', {
     'result': [{


### PR DESCRIPTION
`createCanduit` fails if `HOME` env is missing even if config parameters are passed. This fixes it.
