### PR TITLE
Update endpoint to include "api"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ var createCanduit = require('canduit');
 createCanduit(function (err, canduit) {
 
   // Execute a conduit API call
-  canduit.exec('user.query', {
+  canduit.exec('api/user.query', {
     usernames: ['aleksey']
   }, function (err, users) {
 


### PR DESCRIPTION
The actual endpoint is api/user.query.  Tested by verifying that it worked with 'api/user.query' but not with 'user.query'.